### PR TITLE
Iterators, iterators everywhere!

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
-
 name = "sequence_trie"
-version = "0.0.13"
+version = "0.1.0"
 description = "Trie-like data-structure for storing sequences of values."
 
 license = "MIT"
@@ -13,5 +12,4 @@ repository = "https://github.com/michaelsproul/rust_sequence_trie"
 keywords = ["trie", "tree", "hash", "data-structure", "collection"]
 
 [lib]
-
 name = "sequence_trie"

--- a/benches/vs_hashmap.rs
+++ b/benches/vs_hashmap.rs
@@ -1,7 +1,10 @@
-use std::collections::HashMap;
-use std_test::Bencher;
+#![feature(test)]
+extern crate test;
+extern crate sequence_trie;
 
-use SequenceTrie;
+use std::collections::HashMap;
+use test::Bencher;
+use sequence_trie::SequenceTrie;
 
 macro_rules! u32_benchmark {
     ($map_constructor: expr, $test_id: ident, $num_keys: expr, $key_length: expr) => (

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,6 +91,13 @@ impl<K, V> SequenceTrie<K, V> where K: TrieKey {
         }
     }
 
+    /// Checks if this node is empty.
+    ///
+    /// A node is considered empty when it has no value and no children.
+    pub fn is_empty(&self) -> bool {
+        self.children.is_empty() && self.value.is_none()
+    }
+
     /// Insert a key and value into the SequenceTrie.
     ///
     /// Returns `None` if the key did not already correspond to a value, otherwise the old value is
@@ -228,11 +235,7 @@ impl<K, V> SequenceTrie<K, V> where K: TrieKey {
         }
 
         // If the node is childless and valueless, mark it for deletion.
-        if self.children.is_empty() && self.value.is_none() {
-            true
-        } else {
-            false
-        }
+        self.is_empty()
     }
 
     /// Return an iterator over all the key-value pairs in the collection.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -129,11 +129,11 @@ impl<K, V> SequenceTrie<K, V> where K: TrieKey {
 
     /// Find a mutable reference to a key's value, if it has one.
     pub fn get_mut<'a, I: IntoIterator<Item=&'a K>>(&mut self, key: I) -> Option<&mut V> {
-        self.get_mut_node(key).and_then(|node| node.value.as_mut())
+        self.get_node_mut(key).and_then(|node| node.value.as_mut())
     }
 
     /// Find a mutable reference to a key's node, if it has one.
-    pub fn get_mut_node<'a, I: IntoIterator<Item=&'a K>>(&mut self, key: I) -> Option<&mut SequenceTrie<K, V>> {
+    pub fn get_node_mut<'a, I: IntoIterator<Item=&'a K>>(&mut self, key: I) -> Option<&mut SequenceTrie<K, V>> {
         let mut fragments = key.into_iter();
 
         // Recursive base case, if the key is empty, return the node.
@@ -144,7 +144,7 @@ impl<K, V> SequenceTrie<K, V> where K: TrieKey {
 
         // Otherwise, recurse down the tree.
         match self.children.get_mut(fragment) {
-            Some(node) => node.get_mut_node(fragments),
+            Some(node) => node.get_node_mut(fragments),
             None => None
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,10 +69,10 @@ mod tests;
 #[derive(Debug, Clone)]
 pub struct SequenceTrie<K, V> where K: TrieKey {
     /// Node value.
-    pub value: Option<V>,
+    value: Option<V>,
 
     /// Node children as a hashmap keyed by key fragments.
-    pub children: HashMap<K, SequenceTrie<K, V>>
+    children: HashMap<K, SequenceTrie<K, V>>
 }
 
 /// Aggregate trait for types which can be used to key a `SequenceTrie`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@ use std::iter::Map;
 use std::default::Default;
 
 #[cfg(test)]
-mod test;
+mod tests;
 
 /// A `SequenceTrie` is recursively defined as a value and a map containing child Tries.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,17 +21,17 @@ mod tests;
 /// key fragments onto nodes. The structure is similar to a k-ary tree, except that the children
 /// are stored in `HashMap`s, and there is no bound on the number of children a single node may
 /// have (effectively k = ∞). In a SequenceTrie with `char` key fragments, the key
-/// `['a', 'b', 'c']` might correspond to something like this (warning: not real code).
+/// `['a', 'b', 'c']` might correspond to something like this:
 ///
-/// ```ignore
+/// ```text
 /// SequenceTrie {
-///     value: Some(0u),
+///     value: Some(0),
 ///     children: 'a' => SequenceTrie {
-///         value: Some(1u),
+///         value: Some(1),
 ///         children: 'b' => SequenceTrie {
 ///             value: None,
 ///             children: 'c' => SequenceTrie {
-///                 value: Some(3u),
+///                 value: Some(3),
 ///                 children: Nil
 ///             }
 ///         }
@@ -45,11 +45,12 @@ mod tests;
 ///
 /// The above SequenceTrie could be created using the following sequence of operations:
 ///
-/// ```ignore
-/// let trie: SequenceTrie<char, uint> = SequenceTrie::new();
-/// trie.insert(['a', 'b', 'c'], 3u);
-/// trie.insert([], 0u);
-/// trie.insert(['a'], 1u);
+/// ```
+/// # use sequence_trie::SequenceTrie;
+/// let mut trie: SequenceTrie<char, i32> = SequenceTrie::new();
+/// trie.insert(&['a', 'b', 'c'], 3);
+/// trie.insert(&[], 0);
+/// trie.insert(&['a'], 1);
 /// ```
 ///
 /// The order of insertion is never important.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@
 
 use std::hash::Hash;
 use std::collections::hash_map::{self, HashMap, Entry};
-use std::iter::{IntoIterator, Map};
+use std::iter::IntoIterator;
 use std::default::Default;
 
 #[cfg(test)]
@@ -236,7 +236,7 @@ impl<K, V> SequenceTrie<K, V> where K: TrieKey {
     }
 
     /// Return an iterator over all the key-value pairs in the collection.
-    pub fn iter<'a>(&'a self) -> Iter<'a, K, V> {
+    pub fn iter(&self) -> Iter<K, V> {
         Iter {
             root: self,
             root_visited: false,
@@ -246,24 +246,16 @@ impl<K, V> SequenceTrie<K, V> where K: TrieKey {
     }
 
     /// Return an iterator over all the keys in the trie.
-    pub fn keys<'a>(&'a self) -> Keys<'a, K, V> {
-        // First fn coerced to a fn pointer (borrowed from HashMap impl).
-        fn first<A, B>((a, _): (A, B)) -> A { a }
-        let first: fn(KeyValuePair<'a, K, V>) -> Vec<&'a K> = first;
-
+    pub fn keys(&self) -> Keys<K, V> {
         Keys {
-            inner: self.iter().map(first)
+            inner: self.iter()
         }
     }
 
     /// Return an iterator over all the values stored in the trie.
-    pub fn values<'a>(&'a self) -> Values<'a, K, V> {
-        // Second fn coerced to a fn pointer (borrowed from HashMap impl).
-        fn second<A, B>((_, b): (A, B)) -> B { b }
-        let second: fn(KeyValuePair<'a, K, V>) -> &'a V = second;
-
+    pub fn values(&self) -> Values<K, V> {
         Values {
-            inner: self.iter().map(second)
+            inner: self.iter()
         }
     }
 }
@@ -281,12 +273,12 @@ pub type KeyValuePair<'a, K, V> = (Vec<&'a K>, &'a V);
 
 /// Iterator over the keys of a `SequenceTrie`.
 pub struct Keys<'a, K: 'a, V: 'a> where K: TrieKey {
-    inner: Map<Iter<'a, K, V>, fn(KeyValuePair<'a, K, V>) -> Vec<&'a K>>
+    inner: Iter<'a, K, V>
 }
 
 /// Iterator over the values of a `SequenceTrie`.
 pub struct Values<'a, K: 'a, V: 'a> where K: TrieKey {
-    inner: Map<Iter<'a, K, V>, fn(KeyValuePair<'a, K, V>) -> &'a V>
+    inner: Iter<'a, K, V>
 }
 
 /// Information stored on the iteration stack whilst exploring.
@@ -351,7 +343,7 @@ impl<'a, K, V> Iterator for Keys<'a, K, V> where K: TrieKey {
     type Item = Vec<&'a K>;
 
     fn next(&mut self) -> Option<Vec<&'a K>> {
-        self.inner.next()
+        self.inner.next().map(|(k, _)| k)
     }
 }
 
@@ -359,7 +351,7 @@ impl<'a, K, V> Iterator for Values<'a, K, V> where K: TrieKey {
     type Item = &'a V;
 
     fn next(&mut self) -> Option<&'a V> {
-        self.inner.next()
+        self.inner.next().map(|(_, v)| v)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -119,19 +119,16 @@ impl<K, V> SequenceTrie<K, V> where K: TrieKey {
 
     /// Find a reference to a key's node, if it has one.
     pub fn get_node<'a, I: IntoIterator<Item=&'a K>>(&self, key: I) -> Option<&SequenceTrie<K, V>> {
-        let mut fragments = key.into_iter();
+        let mut current_node = self;
 
-        // Recursive base case, if the key is empty, return the node.
-        let fragment = match fragments.next() {
-            Some(head) => head,
-            None => return Some(self)
-        };
-
-        // Otherwise, recurse down the tree.
-        match self.children.get(fragment) {
-            Some(node) => node.get_node(fragments),
-            None => None
+        for fragment in key {
+            match current_node.children.get(fragment) {
+                Some(node) => current_node = node,
+                None => return None,
+            }
         }
+
+        Some(current_node)
     }
 
     /// Find a mutable reference to a key's value, if it has one.
@@ -141,19 +138,16 @@ impl<K, V> SequenceTrie<K, V> where K: TrieKey {
 
     /// Find a mutable reference to a key's node, if it has one.
     pub fn get_node_mut<'a, I: IntoIterator<Item=&'a K>>(&mut self, key: I) -> Option<&mut SequenceTrie<K, V>> {
-        let mut fragments = key.into_iter();
+        let mut current_node = Some(self);
 
-        // Recursive base case, if the key is empty, return the node.
-        let fragment = match fragments.next() {
-            Some(head) => head,
-            None => return Some(self)
-        };
-
-        // Otherwise, recurse down the tree.
-        match self.children.get_mut(fragment) {
-            Some(node) => node.get_node_mut(fragments),
-            None => None
+        for fragment in key {
+            match current_node.and_then(|node| node.children.get_mut(fragment)) {
+                Some(node) => current_node = Some(node),
+                None => return None,
+            }
         }
+
+        current_node
     }
 
     /// Find the longest prefix of nodes which match the given key.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,11 +2,6 @@
 //!
 //! See the `SequenceTrie` type for documentation.
 
-#![cfg_attr(all(feature = "nightly", test), feature(test))]
-
-#[cfg(all(feature = "nightly", test))]
-extern crate test as std_test;
-
 use std::hash::Hash;
 use std::collections::hash_map::{self, HashMap, Entry};
 use std::iter::Map;
@@ -14,8 +9,6 @@ use std::default::Default;
 
 #[cfg(test)]
 mod test;
-#[cfg(all(feature = "nightly", test))]
-mod benchmark;
 
 /// A `SequenceTrie` is recursively defined as a value and a map containing child Tries.
 ///

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -14,16 +14,14 @@ fn make_trie() -> SequenceTrie<char, u32> {
 #[test]
 fn get() {
     let trie = make_trie();
-    let data = [
-        (vec![], Some(0u32)),
-        (vec!['a'], Some(1u32)),
-        (vec!['a', 'b'], None),
-        (vec!['a', 'b', 'c'], None),
-        (vec!['a', 'b', 'x'], None),
-        (vec!['a', 'b', 'c', 'd'], Some(4u32)),
-        (vec!['a', 'b', 'x', 'y'], Some(25u32)),
-        (vec!['b', 'x', 'y'], None)
-    ];
+    let data = [(vec![], Some(0u32)),
+                (vec!['a'], Some(1u32)),
+                (vec!['a', 'b'], None),
+                (vec!['a', 'b', 'c'], None),
+                (vec!['a', 'b', 'x'], None),
+                (vec!['a', 'b', 'c', 'd'], Some(4u32)),
+                (vec!['a', 'b', 'x', 'y'], Some(25u32)),
+                (vec!['b', 'x', 'y'], None)];
     for &(ref key, value) in data.iter() {
         assert_eq!(trie.get(key), value.as_ref());
     }
@@ -40,17 +38,15 @@ fn get_mut() {
 #[test]
 fn get_ancestor() {
     let trie = make_trie();
-    let data = [
-        (vec![], 0u32),
-        (vec!['a'], 1u32),
-        (vec!['a', 'b'], 1u32),
-        (vec!['a', 'b', 'c'], 1u32),
-        (vec!['a', 'b', 'c', 'd'], 4u32),
-        (vec!['a', 'b', 'x'], 1u32),
-        (vec!['a', 'b', 'x', 'y'], 25u32),
-        (vec!['p', 'q'], 0u32),
-        (vec!['a', 'p', 'q'], 1u32)
-    ];
+    let data = [(vec![], 0u32),
+                (vec!['a'], 1u32),
+                (vec!['a', 'b'], 1u32),
+                (vec!['a', 'b', 'c'], 1u32),
+                (vec!['a', 'b', 'c', 'd'], 4u32),
+                (vec!['a', 'b', 'x'], 1u32),
+                (vec!['a', 'b', 'x', 'y'], 25u32),
+                (vec!['p', 'q'], 0u32),
+                (vec!['a', 'p', 'q'], 1u32)];
     for &(ref key, value) in data.iter() {
         assert_eq!(*trie.get_ancestor(key).unwrap(), value);
     }
@@ -70,7 +66,7 @@ fn get_prefix_nodes() {
 
 #[test]
 fn remove() {
-    let mut trie= make_trie();
+    let mut trie = make_trie();
     // If the node has children, its value should be set to `None`.
     println!("Remove ['a']");
     println!("Before: {:?}", trie);
@@ -114,9 +110,9 @@ fn remove() {
 #[test]
 fn key_iter() {
     let trie = make_trie();
-    let obs_keys: HashSet<Vec<char>> = trie.keys().map(|v| -> Vec<char> {
-        v.iter().map(|&&x| x).collect()
-    }).collect();
+    let obs_keys: HashSet<Vec<char>> = trie.keys()
+        .map(|v| -> Vec<char> { v.iter().map(|&&x| x).collect() })
+        .collect();
     let mut exp_keys: HashSet<Vec<char>> = HashSet::new();
     exp_keys.insert(vec![]);
     exp_keys.insert(vec!['a']);
@@ -127,7 +123,7 @@ fn key_iter() {
 
 #[derive(PartialEq, Eq, Hash, Clone)]
 struct Key {
-    field: usize
+    field: usize,
 }
 
 #[test]

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,6 +1,6 @@
 use std::collections::HashSet;
 
-use SequenceTrie;
+use super::SequenceTrie;
 
 fn make_trie() -> SequenceTrie<char, u32> {
     let mut trie = SequenceTrie::new();


### PR DESCRIPTION
Obligatory: ![](https://i.imgflip.com/16ze2v.jpg)

In this PR there are many small cleanups / refactorings to better match Rust conventions, and two bigger changes:

- the `key` parameter types were changed to iterators, to improve usability
- new iterator `PrefixIter` that iterates over the prefix nodes

The version is bumped because there are many breaking changes in this PR.

Closes #21 (technically it was already fixed)

**For #24** 
I license past and future contributions under the dual MIT/Apache-2.0 license, allowing licensees to chose either at their option.