### PR TITLE
Use to_owned instead of clone for inserts.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sequence_trie"
-version = "0.1.0"
+version = "0.2.0"
 description = "Trie-like data-structure for storing sequences of values."
 
 license = "MIT"

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -189,3 +189,12 @@ fn default() {
     let empty_trie: SequenceTrie<u8, i32> = ::std::default::Default::default();
     assert_eq!(empty_trie, SequenceTrie::new());
 }
+
+#[test]
+fn string_trie() {
+    let mut trie: SequenceTrie<String, ()> = SequenceTrie::new();
+    trie.insert_owned(vec!["hello".to_string(), "world".to_string()], ());
+    trie.insert(&["hello".to_string(), "world".to_string()], ());
+    trie.insert(vec!["hello", "world"], ());
+    trie.insert(["hello", "world"].iter().map(|&x| x), ());
+}


### PR DESCRIPTION
This allows us to create String tries using iterators over &str.

I came up with this while trying to upgrade the main dependent crate, [iron/mount](https://github.com/iron/mount), to use the new iterator API.