### PR TITLE
Remove the TrieKey trait in favour of Eq + Hash bounds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sequence_trie"
-version = "0.3.3"
+version = "0.3.4"
 description = "Trie-like data-structure for storing sequences of values."
 
 license = "MIT/Apache-2.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,8 +86,8 @@ pub struct SequenceTrie<K, V, S = RandomState>
 ///
 /// This trait is automatically implemented for all types implementing
 /// the supertraits.
-pub trait TrieKey: 'static + PartialEq + Eq + Hash + Clone {}
-impl<K> TrieKey for K where K: 'static + PartialEq + Eq + Hash + Clone {}
+pub trait TrieKey: Eq + Hash {}
+impl<K> TrieKey for K where K: Eq + Hash {}
 
 impl<K, V> SequenceTrie<K, V>
     where K: TrieKey


### PR DESCRIPTION
See issue https://github.com/michaelsproul/rust_sequence_trie/issues/34