### PR TITLE
Serde and BTreeMap support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,7 @@ os:
   - linux
 script:
   - cargo test --verbose
+  - cargo test --verbose --features=serde
+  - cargo test --verbose --features=btreemap
+  - cargo test --verbose --features=serde,btreemap
   - cargo doc --no-deps

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,3 +20,6 @@ btreemap = []
 
 [dependencies]
 serde = { version = "^1.0", optional = true, features = ["derive"] }
+
+[dev-dependencies]
+serde_json = "^1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,6 @@ keywords = ["trie", "tree", "hash", "data-structure", "collection"]
 
 [lib]
 name = "sequence_trie"
+
+[features]
+btreemap = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,6 @@ name = "sequence_trie"
 
 [features]
 btreemap = []
+
+[dependencies]
+serde = { version = "^1.0", optional = true, features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,3 +23,7 @@ serde = { version = "^1.0", optional = true, features = ["derive"] }
 
 [dev-dependencies]
 serde_json = "^1.0"
+
+[[example]]
+name = "json"
+required-features = ["serde"]

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [Sequence Trie][doc]
 ====
 
-[![Build Status](https://travis-ci.org/michaelsproul/rust_sequence_trie.svg)](https://travis-ci.org/michaelsproul/rust_sequence_trie)
+[![Build Status](https://travis-ci.org/michaelsproul/rust_sequence_trie.svg?branch=master)](https://travis-ci.org/michaelsproul/rust_sequence_trie)
 
 This is a generic Trie implementation that uses a hash map to store child nodes. The Trie is keyed by lists of type `K`, which can be anything implementing `PartialEq`, `Eq`, `Hash` and `Clone`. If your keys are explicit lists and you want to be able to store a different value for each element of a key, this might be the data structure for you!
 

--- a/examples/json.rs
+++ b/examples/json.rs
@@ -1,0 +1,12 @@
+extern crate sequence_trie;
+extern crate serde_json;
+
+use sequence_trie::SequenceTrie;
+
+fn main() {
+    let mut trie = SequenceTrie::new();
+    trie.insert(&["hello", "world"], 56);
+    trie.insert(&["hello", "moon"], 57);
+
+    println!("{}", serde_json::to_string_pretty(&trie).unwrap());
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,9 +26,10 @@ use serde::{Serialize, Deserialize};
 #[macro_use]
 extern crate serde;
 
-
 #[cfg(test)]
 mod tests;
+#[cfg(all(test, feature = "serde"))]
+mod serde_tests;
 
 /// A `SequenceTrie` is recursively defined as a value and a map containing child Tries.
 ///
@@ -131,12 +132,12 @@ pub struct SequenceTrie<K, V, S = RandomState>
 #[cfg(not(feature = "btreemap"))]
 pub trait TrieKey: Eq + Hash {}
 #[cfg(not(feature = "btreemap"))]
-impl<K> TrieKey for K where K: Eq + Hash {}
+impl<K> TrieKey for K where K: Eq + Hash + ?Sized {}
 
 #[cfg(feature = "btreemap")]
 pub trait TrieKey: Ord {}
 #[cfg(feature = "btreemap")]
-impl<K> TrieKey for K where K: Ord {}
+impl<K> TrieKey for K where K: Ord + ?Sized {}
 
 #[cfg(not(feature = "btreemap"))]
 impl<K, V> SequenceTrie<K, V>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,10 @@ use std::borrow::{Borrow, ToOwned};
 use std::mem;
 use std::marker::PhantomData;
 
+#[cfg(feature = "serde")]
+#[macro_use]
+extern crate serde;
+
 #[cfg(test)]
 mod tests;
 
@@ -78,6 +82,8 @@ mod tests;
 /// # The Sequence Trie Invariant
 /// All leaf nodes have non-trivial values (not equal to `None`). This invariant is maintained by
 /// the insertion and removal methods and can be relied upon.
+#[cfg(feature = "serde")]
+#[derive(Serialize, Deserialize)]
 #[derive(Debug, Clone)]
 #[cfg(not(feature = "btreemap"))]
 pub struct SequenceTrie<K, V, S = RandomState>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,13 +82,12 @@ mod tests;
 /// # The Sequence Trie Invariant
 /// All leaf nodes have non-trivial values (not equal to `None`). This invariant is maintained by
 /// the insertion and removal methods and can be relied upon.
-#[cfg(feature = "serde")]
-#[derive(Serialize, Deserialize)]
 #[derive(Debug, Clone)]
 #[cfg(not(feature = "btreemap"))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct SequenceTrie<K, V, S = RandomState>
     where K: TrieKey,
-          S: BuildHasher,
+          S: BuildHasher + Default,
 {
     /// Node value.
     value: Option<V>,
@@ -99,9 +98,10 @@ pub struct SequenceTrie<K, V, S = RandomState>
 
 #[derive(Debug, Clone)]
 #[cfg(feature = "btreemap")]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct SequenceTrie<K, V, S = RandomState>
     where K: TrieKey,
-          S: BuildHasher,
+          S: BuildHasher + Default,
 {
     /// Node value.
     value: Option<V>,
@@ -140,7 +140,7 @@ impl<K, V> SequenceTrie<K, V>
 #[cfg(not(feature = "btreemap"))]
 impl<K, V, S> SequenceTrie<K, V, S>
     where K: TrieKey,
-          S: BuildHasher + Clone,
+          S: BuildHasher + Default + Clone,
 {
     pub fn with_hasher(hash_builder: S) -> SequenceTrie<K, V, S> {
         SequenceTrie {
@@ -163,7 +163,7 @@ impl<K, V> SequenceTrie<K, V>
 #[cfg(feature = "btreemap")]
 impl<K, V, S> SequenceTrie<K, V, S>
     where K: TrieKey,
-          S: BuildHasher + Clone,
+          S: BuildHasher + Default + Clone,
 {
     /// Creates a new `SequenceTrie` node with no value and an empty child map.
     pub fn new_generic() -> SequenceTrie<K, V, S> {
@@ -177,7 +177,7 @@ impl<K, V, S> SequenceTrie<K, V, S>
 
 impl<K, V, S> SequenceTrie<K, V, S>
     where K: TrieKey,
-          S: BuildHasher + Clone,
+          S: BuildHasher + Default + Clone,
 {
     /// Retrieve the value stored at this node.
     pub fn value(&self) -> Option<&V> {
@@ -456,7 +456,7 @@ impl<K, V, S> SequenceTrie<K, V, S>
 /// Iterator over the keys and values of a `SequenceTrie`.
 pub struct Iter<'a, K: 'a, V: 'a, S: 'a = RandomState>
     where K: TrieKey,
-          S: BuildHasher
+          S: BuildHasher + Default
 {
     root: &'a SequenceTrie<K, V, S>,
     root_visited: bool,
@@ -470,7 +470,7 @@ pub type KeyValuePair<'a, K, V> = (Vec<&'a K>, &'a V);
 /// Iterator over the keys of a `SequenceTrie`.
 pub struct Keys<'a, K: 'a, V: 'a, S: 'a = RandomState>
     where K: TrieKey,
-          S: BuildHasher
+          S: BuildHasher + Default
 {
     inner: Iter<'a, K, V, S>,
 }
@@ -478,7 +478,7 @@ pub struct Keys<'a, K: 'a, V: 'a, S: 'a = RandomState>
 /// Iterator over the values of a `SequenceTrie`.
 pub struct Values<'a, K: 'a, V: 'a, S: 'a = RandomState>
     where K: TrieKey,
-          S: BuildHasher
+          S: BuildHasher + Default
 {
     inner: Iter<'a, K, V, S>,
 }
@@ -486,7 +486,7 @@ pub struct Values<'a, K: 'a, V: 'a, S: 'a = RandomState>
 /// Information stored on the iteration stack whilst exploring.
 struct StackItem<'a, K: 'a, V: 'a, S: 'a = RandomState>
     where K: TrieKey,
-          S: BuildHasher
+          S: BuildHasher + Default
 {
     #[cfg(not(feature = "btreemap"))]
     child_iter: hash_map::Iter<'a, K, SequenceTrie<K, V, S>>,
@@ -497,7 +497,7 @@ struct StackItem<'a, K: 'a, V: 'a, S: 'a = RandomState>
 /// Delayed action type for iteration stack manipulation.
 enum IterAction<'a, K: 'a, V: 'a, S: 'a>
     where K: TrieKey,
-          S: BuildHasher
+          S: BuildHasher + Default
 {
     Push(&'a K, &'a SequenceTrie<K, V, S>),
     Pop,
@@ -505,7 +505,7 @@ enum IterAction<'a, K: 'a, V: 'a, S: 'a>
 
 impl<'a, K, V, S> Iterator for Iter<'a, K, V, S>
     where K: TrieKey,
-          S: BuildHasher
+          S: BuildHasher + Default
 {
     type Item = KeyValuePair<'a, K, V>;
 
@@ -551,7 +551,7 @@ impl<'a, K, V, S> Iterator for Iter<'a, K, V, S>
 
 impl<'a, K, V, S> Iterator for Keys<'a, K, V, S>
     where K: TrieKey,
-          S: BuildHasher,
+          S: BuildHasher + Default,
 {
     type Item = Vec<&'a K>;
 
@@ -562,7 +562,7 @@ impl<'a, K, V, S> Iterator for Keys<'a, K, V, S>
 
 impl<'a, K, V, S> Iterator for Values<'a, K, V, S>
     where K: TrieKey,
-          S: BuildHasher
+          S: BuildHasher + Default
 {
     type Item = &'a V;
 
@@ -574,7 +574,7 @@ impl<'a, K, V, S> Iterator for Values<'a, K, V, S>
 impl<K, V, S> PartialEq for SequenceTrie<K, V, S>
     where K: TrieKey,
           V: PartialEq,
-          S: BuildHasher
+          S: BuildHasher + Default
 {
     fn eq(&self, other: &Self) -> bool {
         self.value == other.value && self.children == other.children
@@ -584,12 +584,12 @@ impl<K, V, S> PartialEq for SequenceTrie<K, V, S>
 impl<K, V, S> Eq for SequenceTrie<K, V, S>
     where K: TrieKey,
           V: Eq,
-          S: BuildHasher
+          S: BuildHasher + Default
 {}
 
 impl<K, V, S> Default for SequenceTrie<K, V, S>
     where K: TrieKey,
-          S: Default + BuildHasher + Clone
+          S: Default + BuildHasher + Default + Clone
 {
     fn default() -> Self {
         #[cfg(not(feature = "btreemap"))]
@@ -606,7 +606,7 @@ pub struct PrefixIter<'trie, 'key, K, V, Q: ?Sized, I, S = RandomState>
           I: 'key + Iterator<Item = &'key Q>,
           K: Borrow<Q>,
           Q: TrieKey + 'key,
-          S: 'trie + BuildHasher
+          S: 'trie + BuildHasher + Default
 {
     next_node: Option<&'trie SequenceTrie<K, V, S>>,
     fragments: I,
@@ -619,7 +619,7 @@ impl<'trie, 'key, K, V, Q: ?Sized, I, S> Iterator for PrefixIter<'trie, 'key, K,
           I: 'key + Iterator<Item = &'key Q>,
           K: Borrow<Q>,
           Q: TrieKey + 'key,
-          S: BuildHasher
+          S: BuildHasher + Default
 {
     type Item = &'trie SequenceTrie<K, V, S>;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,8 +20,12 @@ use std::mem;
 use std::marker::PhantomData;
 
 #[cfg(feature = "serde")]
+use serde::{Serialize, Deserialize};
+
+#[cfg(feature = "serde")]
 #[macro_use]
 extern crate serde;
+
 
 #[cfg(test)]
 mod tests;
@@ -85,6 +89,9 @@ mod tests;
 #[derive(Debug, Clone)]
 #[cfg(not(feature = "btreemap"))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(bound(serialize = "K: Serialize, V: Serialize")))]
+#[cfg_attr(feature = "serde",
+    serde(bound(deserialize = "K: Deserialize<'de>, V: Deserialize<'de>")))]
 pub struct SequenceTrie<K, V, S = RandomState>
     where K: TrieKey,
           S: BuildHasher + Default,
@@ -99,6 +106,9 @@ pub struct SequenceTrie<K, V, S = RandomState>
 #[derive(Debug, Clone)]
 #[cfg(feature = "btreemap")]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(bound(serialize = "K: Serialize, V: Serialize")))]
+#[cfg_attr(feature = "serde",
+    serde(bound(deserialize = "K: Deserialize<'de>, V: Deserialize<'de>")))]
 pub struct SequenceTrie<K, V, S = RandomState>
     where K: TrieKey,
           S: BuildHasher + Default,
@@ -110,6 +120,7 @@ pub struct SequenceTrie<K, V, S = RandomState>
     children: BTreeMap<K, SequenceTrie<K, V, S>>,
 
     /// Fake hasher for compatibility.
+    #[cfg_attr(feature = "serde", serde(skip))]
     _phantom: PhantomData<S>,
 }
 
@@ -589,7 +600,7 @@ impl<K, V, S> Eq for SequenceTrie<K, V, S>
 
 impl<K, V, S> Default for SequenceTrie<K, V, S>
     where K: TrieKey,
-          S: Default + BuildHasher + Default + Clone
+          S: BuildHasher + Default + Clone
 {
     fn default() -> Self {
         #[cfg(not(feature = "btreemap"))]

--- a/src/serde_tests.rs
+++ b/src/serde_tests.rs
@@ -1,0 +1,52 @@
+extern crate serde_json;
+
+use super::SequenceTrie;
+
+type TestTrie = SequenceTrie<String, u32>;
+
+fn test_trie() -> TestTrie {
+    let mut trie = SequenceTrie::new();
+    trie.insert(vec!["a"], 1u32);
+    trie.insert(vec!["a", "b", "c", "d"], 4u32);
+    trie.insert(vec!["a", "b", "x", "y"], 25u32);
+    trie
+}
+
+#[test]
+fn roundtrip() {
+    let trie = test_trie();
+    let rtrip = serde_json::to_string(&trie)
+        .and_then(|s| serde_json::from_str::<TestTrie>(&s))
+        .unwrap();
+    assert_eq!(rtrip, trie);
+}
+
+#[test]
+fn json_deserialise() {
+    let test_str = r#"
+        {
+          "value": null,
+          "children": {
+            "hello": {
+              "value": null,
+              "children": {
+                "world": {
+                  "value": 56,
+                  "children": {}
+                },
+                "moon": {
+                  "value": 57,
+                  "children": {}
+                }
+              }
+            }
+          }
+        }
+    "#;
+
+    let trie = serde_json::from_str::<TestTrie>(test_str).unwrap();
+
+    assert_eq!(trie.get(vec!["hello"]), None);
+    assert_eq!(trie.get(vec!["hello", "world"]), Some(&56));
+    assert_eq!(trie.get(vec!["hello", "moon"]), Some(&57));
+}

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -121,7 +121,7 @@ fn key_iter() {
     assert_eq!(exp_keys, obs_keys);
 }
 
-#[derive(PartialEq, Eq, Hash, Clone)]
+#[derive(PartialEq, Eq, Hash, Clone, PartialOrd, Ord)]
 struct Key {
     field: usize,
 }


### PR DESCRIPTION
This PR mashes together a whole lot of code that's been hanging around for a while.

I took my `btreemap` branch, which allowed optionally switching the `SequenceTrie`'s inner `HashMap` for a `BTreeMap`, and applied @kyrias's work on serialisation/deserialisation. Then, to make the serialisation and deserialisation play nicely with the `HashMap` related stuff, I added some attributes to guide `serde_derive`'s code generation. There are a few tests to make sure it all works, but the resulting code isn't exactly pretty!

If you'd like to try the Serde + JSON serialisation, you can run:

```
$ cargo run --features=serde --example json
```